### PR TITLE
[INITIAL] Promote Rule 11 commit-size gate as canonical template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to hardgate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `templates/commit-size-gate/` — canonical reusable template for Rule 11 (Commit-Size Acknowledgment Gate). Byte-identical to the validated production deployment in `civiccore`, `scottconverse/patentforgelocal` (commit `007e924`), and `scottconverse/productteam` (commit `76333aa`). `THRESHOLD=800` insertions+deletions (non-binary), literal-bracketed-token matching (`[MVP]` / `[LARGE-CHANGE]` / `[REFACTOR]` / `[INITIAL]` / `[MERGE]` / `[REVERT]` / `[SCOPE-EXPANSION: <reason>]`), fail-open on `--amend` / `-F` / editor commits, 60-second `override rule 11` one-shot pressure valve. Template README at `templates/commit-size-gate/README.md` covers install steps and verification recipe; `tests/commit_size_gate_template_test.py` provides a pytest smoke test against the real template file.
+
 ## [1.1.0] — 2026-04-14
 
 ### v1.1.0 Sprint 1 — quick wins (7 audit items)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Level 3 is the one that matters. The model cannot bypass a hook that returns `ex
 
 ---
 
+## Canonical templates
+
+For commonly-used gates, hardgate ships reference implementations under `templates/` that can be copied directly into a project's `.claude/hooks/` — skipping the full `/hard-gate` installer flow when you just want a known-good gate.
+
+- **[`templates/commit-size-gate/`](templates/commit-size-gate/)** — reference implementation for Rule 11 (Commit-Size Acknowledgment Gate). Blocks `git commit` when the staged diff exceeds `THRESHOLD` (default 800 lines) and the message lacks one of the allowed bracketed tag tokens; 60-second `override rule 11` one-shot pressure valve. See [`templates/commit-size-gate/README.md`](templates/commit-size-gate/README.md) for install steps, settings.json wiring, and the verification recipe.
+
+Each template is byte-identical to a validated production deployment and covered by its own pytest smoke test under `tests/`.
+
+---
+
 ## Requirements
 
 - **Claude Desktop** with Cowork enabled (Windows or Mac), or **Claude Code CLI**

--- a/templates/commit-size-gate/README.md
+++ b/templates/commit-size-gate/README.md
@@ -1,0 +1,125 @@
+# commit-size-gate — canonical template
+
+A project-level PreToolUse hook that blocks `git commit` when the staged diff
+exceeds `THRESHOLD` lines (insertions + deletions, ignoring binary files) and
+the commit message does not contain one of the allowed literal bracketed tag
+tokens. Intent: keep commits small and reviewable; when a change is genuinely
+large, force explicit acknowledgment via a tag rather than silent bloat.
+
+This is the canonical reference implementation for the rule installed as
+**Hard Rule 11 — Commit-Size Acknowledgment Gate** in `~/.claude/CLAUDE.md`.
+
+## Allowed tag tokens
+
+Literal bracketed match only — substrings like "the MVP flow" do NOT satisfy:
+
+```
+[MVP]  [LARGE-CHANGE]  [REFACTOR]  [INITIAL]  [MERGE]  [REVERT]
+[SCOPE-EXPANSION: <reason>]
+```
+
+## Tunables (top of `commit-size-gate.py`)
+
+- `THRESHOLD = 800` — staged insertions + deletions
+- `OVERRIDE_WINDOW_SECONDS = 60` — `override rule 11` one-shot bypass window
+
+## Bypass surfaces (fail-open, by design)
+
+The hook does **not** fire on:
+
+- `git commit --amend` — final message not reliably parseable at PreToolUse
+- `git commit -F <file>` — message lives in a file the hook can't read safely
+- editor commits (no `-m` flag) — message comes from `$EDITOR` post-hook
+- any exception in the script — fail-open so a hook bug never locks the user out
+
+If you amend into a large commit, self-police with the tag on the next real
+`-m` commit.
+
+## Pressure valve
+
+The user says the literal phrase `override rule 11`. Claude (or the user)
+writes the current timestamp to:
+
+- `$CLAUDE_PROJECT_DIR/.claude/hardgate-override-rule-11` (project-level), or
+- `$HOME/.claude/hardgate-override-rule-11` (user-level)
+
+The hook reads the marker, confirms `mtime < OVERRIDE_WINDOW_SECONDS`, deletes
+it, and allows the next `git commit` through once.
+
+## Install
+
+From the project root:
+
+```bash
+mkdir -p .claude/hooks
+cp /path/to/hardgate/templates/commit-size-gate/commit-size-gate.py            .claude/hooks/
+cp /path/to/hardgate/templates/commit-size-gate/commit-size-gate.sh            .claude/hooks/
+cp /path/to/hardgate/templates/commit-size-gate/commit-size-session-start.py   .claude/hooks/
+cp /path/to/hardgate/templates/commit-size-gate/commit-size-session-start.sh   .claude/hooks/
+```
+
+Then wire into `.claude/settings.json` (merge with any existing `hooks` block):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/commit-size-gate.sh\""}
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {"type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/commit-size-session-start.sh\""}
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Verify post-install (4 behavioral tests)
+
+Seed two throwaway repos: one with `>THRESHOLD` staged lines, one with a small
+staged diff. For each of the four tests below, pipe a PreToolUse JSON payload
+to `commit-size-gate.py` with `CLAUDE_PROJECT_DIR` pointed at the appropriate
+seed repo:
+
+| # | Staged diff | Commit message | Expected |
+|---|---|---|---|
+| 1 | 900 lines | `"big change"` (no tag) | **BLOCK** (exit 2) |
+| 2 | 900 lines | `"[MVP] big change"` | **ALLOW** (exit 0) |
+| 3 | 25 lines | `"tiny fix"` (no tag) | **ALLOW** (exit 0) |
+| 4 | 900 lines | `"fixed a bug with the MVP flow"` (substring, no brackets) | **BLOCK** (exit 2) |
+
+Test 4 proves the literal-bracketed-token regex is working; if substring
+matching were active, test 4 would have allowed.
+
+## Validation provenance
+
+This template is the exact file set deployed and behaviorally verified in:
+
+- `scottconverse/civiccore` — validation project (`.claude/` gitignored, local-only)
+- `scottconverse/patentforgelocal` — commit `007e924`, repo-shared
+- `scottconverse/productteam` (via `productteam-v2` working copy) — commit `76333aa`, repo-shared
+
+Also wired (local-only, `.claude/` gitignored) in `scottconverse/civicrecords-ai`.
+
+All four behavioral tests above passed 12/12 across the three active projects
+during rollout. Hook constants and regexes are byte-identical to the validated
+deployment.
+
+## Scope — what this template does NOT do
+
+- Does not modify any `CLAUDE.md` (rule text lives in `~/.claude/CLAUDE.md`).
+- Does not install other supervisor-mode artifacts (no honesty gate, no scope
+  gate, no secrets gate, no `tasks.md`, no `handoff.md`, no `tests/uat/`).
+- Does not touch project `.gitignore`. Projects choose `LOCAL_ONLY`
+  (gitignore `.claude/`) vs `REPO_SHARED` (commit `.claude/`) themselves.
+- Does not dispatch subagents or generate cards. Companion skill
+  `supervisor-card` (at `~/.claude/skills/supervisor-card/`) handles
+  `docs/SUPERVISOR.md` generation separately.

--- a/templates/commit-size-gate/commit-size-gate.py
+++ b/templates/commit-size-gate/commit-size-gate.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Commit-Size Acknowledgment Gate — Hard Rule 11
+
+Blocks `git commit` when:
+  (a) the staged diff exceeds THRESHOLD lines (insertions + deletions,
+      ignoring binary files as reported by `git diff --cached --numstat`), AND
+  (b) the commit message parsed from `-m` / `--message` does NOT contain
+      one of the allowed literal bracketed tag tokens.
+
+Allowed tokens (literal bracketed match, NOT substring):
+    [MVP]  [LARGE-CHANGE]  [REFACTOR]  [INITIAL]  [MERGE]  [REVERT]
+    [SCOPE-EXPANSION: <reason>]
+
+So "fixed a bug with the MVP flow" does NOT satisfy the gate.
+Only "[MVP] ..." or "[SCOPE-EXPANSION: why] ..." do.
+
+BYPASS SURFACES (gate is FAIL-OPEN for all of these):
+  - `git commit --amend`    — final message not parseable at PreToolUse
+  - `git commit -F <file>`  — message lives in a file the hook can't read reliably
+  - editor commits (no -m)  — message comes from $EDITOR post-hook
+  - any exception in this script — fail-open by design (never lock the user out)
+  - `override rule 11` marker file (60-second one-shot, deleted on use)
+
+If you amend into a large commit, self-police with the tag on the next
+real -m commit. The gate intentionally does not chase --amend/-F/editor
+commits because parsing them reliably would require a post-commit hook,
+which is a different enforcement surface.
+
+THRESHOLD is tunable — see constant at the top of main() below.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# --- TUNABLES ---------------------------------------------------------------
+
+THRESHOLD = 800  # staged insertions + deletions (non-binary files)
+OVERRIDE_WINDOW_SECONDS = 60  # `override rule 11` one-shot bypass window
+
+# --- MATCHING ---------------------------------------------------------------
+
+# Literal bracketed tokens. NOT substring matches.
+TAG_RE = re.compile(r"\[(MVP|LARGE-CHANGE|REFACTOR|INITIAL|MERGE|REVERT)\]")
+SCOPE_EXPANSION_RE = re.compile(r"\[SCOPE-EXPANSION:\s*[^\]]+\]")
+
+# -m / --message parsing. Matches:  -m "msg" | -m 'msg' | --message="msg" | -m msg_no_quotes
+MSG_RE_QUOTED = re.compile(r"""(?:-m|--message)[=\s]+(["'])(.+?)\1""", re.DOTALL)
+MSG_RE_BARE = re.compile(r"""(?:-m|--message)[=\s]+(\S+)""")
+
+# Bypass-surface detection (fail-open for these)
+AMEND_RE = re.compile(r"(?<!\S)--amend(?!\S)")
+FILE_MSG_RE = re.compile(r"(?<!\S)(?:-F|--file)(?:=|\s+)")
+
+
+def has_allowed_tag(msg: str) -> bool:
+    return bool(TAG_RE.search(msg) or SCOPE_EXPANSION_RE.search(msg))
+
+
+def extract_message(cmd: str) -> str | None:
+    """Return the -m / --message value, or None if absent."""
+    m = MSG_RE_QUOTED.search(cmd)
+    if m:
+        return m.group(2)
+    m = MSG_RE_BARE.search(cmd)
+    if m:
+        return m.group(1)
+    return None
+
+
+def staged_line_count(project_dir: Path) -> int | None:
+    """Sum insertions + deletions from git diff --cached --numstat.
+    Binary files show '-' for both columns and are ignored.
+    Returns None on any parse / subprocess error (caller should fail-open).
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--cached", "--numstat"],
+            cwd=project_dir,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+
+    total = 0
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        ins, dels = parts[0], parts[1]
+        if ins == "-" or dels == "-":
+            continue  # binary file
+        try:
+            total += int(ins) + int(dels)
+        except ValueError:
+            continue
+    return total
+
+
+def check_override(project_dir: Path) -> bool:
+    """Check for one-shot override marker. Delete on use. Returns True if overridden."""
+    for candidate in (
+        project_dir / ".claude" / "hardgate-override-rule-11",
+        Path.home() / ".claude" / "hardgate-override-rule-11",
+    ):
+        if not candidate.exists():
+            continue
+        try:
+            age = time.time() - candidate.stat().st_mtime
+            if age <= OVERRIDE_WINDOW_SECONDS:
+                candidate.unlink(missing_ok=True)
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # fail-open
+
+    if data.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    cmd = (data.get("tool_input") or {}).get("command", "").strip()
+    if not cmd or "git commit" not in cmd:
+        sys.exit(0)
+
+    # Bypass surfaces — fail-open by design (documented above)
+    if AMEND_RE.search(cmd) or FILE_MSG_RE.search(cmd):
+        sys.exit(0)
+
+    msg = extract_message(cmd)
+    if msg is None:
+        # Editor commit — not parseable at PreToolUse time; fail-open
+        sys.exit(0)
+
+    # If an allowed tag is already present, allow through regardless of size
+    if has_allowed_tag(msg):
+        sys.exit(0)
+
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+
+    # Override pressure valve — one-shot, 60 second window
+    if check_override(project_dir):
+        print("[HARD-RULE-11] override rule 11 accepted — bypassing once.", file=sys.stderr)
+        sys.exit(0)
+
+    total = staged_line_count(project_dir)
+    if total is None or total <= THRESHOLD:
+        sys.exit(0)  # under threshold, or parse error (fail-open)
+
+    # BLOCKED
+    print(f"[HARD-RULE-11] BLOCKED — Commit-Size Acknowledgment Gate.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"Staged diff is {total} lines (threshold: {THRESHOLD}) and the commit", file=sys.stderr)
+    print("message contains no explicit size-acknowledgment tag.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Add one of these literal bracketed tokens to the commit message:", file=sys.stderr)
+    print("    [MVP]  [LARGE-CHANGE]  [REFACTOR]  [INITIAL]  [MERGE]  [REVERT]", file=sys.stderr)
+    print("    [SCOPE-EXPANSION: <reason>]", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Example:", file=sys.stderr)
+    print('    git commit -m "[LARGE-CHANGE] service extraction + schema split"', file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Or split the commit into smaller reviewable pieces.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Pressure valve (user-only): say `override rule 11` to arm a", file=sys.stderr)
+    print(f"{OVERRIDE_WINDOW_SECONDS}-second one-shot bypass.", file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/commit-size-gate/commit-size-gate.sh
+++ b/templates/commit-size-gate/commit-size-gate.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/commit-size-gate.py"

--- a/templates/commit-size-gate/commit-size-session-start.py
+++ b/templates/commit-size-gate/commit-size-session-start.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+SessionStart companion for commit-size-gate (Hard Rule 11).
+
+Injects a one-line reminder that the gate is active in this project,
+so the assistant pre-tags large commits rather than hitting exit 2
+and retrying. Advisory only — does not block.
+"""
+
+import json
+import sys
+
+MSG = (
+    "Hard Rule 11 (Commit-Size Acknowledgment Gate) is active in this project. "
+    "Any `git commit` with >800 staged lines must include one of: "
+    "[MVP] [LARGE-CHANGE] [REFACTOR] [INITIAL] [MERGE] [REVERT] "
+    "[SCOPE-EXPANSION: reason]. "
+    "Bypass surfaces (fail-open): --amend, -F, editor commits. "
+    "Pressure valve: user says `override rule 11` for a 60-second one-shot."
+)
+
+json.dump({"additionalContext": MSG}, sys.stdout)
+sys.exit(0)

--- a/templates/commit-size-gate/commit-size-session-start.sh
+++ b/templates/commit-size-gate/commit-size-session-start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/commit-size-session-start.py"

--- a/tests/commit_size_gate_template_test.py
+++ b/tests/commit_size_gate_template_test.py
@@ -1,0 +1,105 @@
+"""Smoke tests for templates/commit-size-gate/commit-size-gate.py — Rule 11.
+
+Covers the four behavioral cases validated before promotion in civiccore,
+scottconverse/patentforgelocal (commit 007e924), and scottconverse/productteam
+(commit 76333aa):
+
+- 900-line staged diff, no tag                → BLOCK (exit 2)
+- 900-line staged diff, "[MVP]" tag           → ALLOW (exit 0)
+- 25-line staged diff, no tag                  → ALLOW (exit 0)
+- 900-line staged diff, substring "MVP flow"   → BLOCK (exit 2)
+
+Tests execute the real template file via subprocess with a temporary git repo
+providing real `git diff --cached --numstat` output. No fixture copy.
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+TEMPLATE_GATE = REPO_ROOT / "templates" / "commit-size-gate" / "commit-size-gate.py"
+
+
+def _init_repo_with_staged(tmp_path: pathlib.Path, lines: int) -> pathlib.Path:
+    """Initialize a git repo and stage `lines` new lines in big.txt.
+
+    A seed commit is made first so HEAD exists and `git diff --cached` has a
+    well-defined parent to diff against.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.local"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=tmp_path, check=True)
+    (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=tmp_path, check=True)
+
+    content = "".join(f"line {i}\n" for i in range(lines))
+    (tmp_path / "big.txt").write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", "big.txt"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def _run(cmd: str, project_dir: pathlib.Path) -> int:
+    """Invoke the template gate with `CLAUDE_PROJECT_DIR=project_dir` and a
+    Bash PreToolUse payload containing `cmd`. Return the exit code.
+    """
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+    result = subprocess.run(
+        [sys.executable, str(TEMPLATE_GATE)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.returncode
+
+
+def test_template_file_exists():
+    assert TEMPLATE_GATE.is_file(), (
+        f"Template gate not found at {TEMPLATE_GATE}. Promotion commit may be missing."
+    )
+
+
+class TestCommitSizeGateTemplate:
+    def test_900_no_tag_blocks(self, tmp_path):
+        _init_repo_with_staged(tmp_path, 900)
+        code = _run('git commit -m "big change"', tmp_path)
+        assert code == 2, (
+            "900-line staged diff with no tag must BLOCK (exit 2). "
+            f"Got exit {code}."
+        )
+
+    def test_900_with_mvp_tag_allows(self, tmp_path):
+        _init_repo_with_staged(tmp_path, 900)
+        code = _run('git commit -m "[MVP] big change"', tmp_path)
+        assert code == 0, (
+            "900-line staged diff with [MVP] tag must ALLOW (exit 0). "
+            f"Got exit {code}."
+        )
+
+    def test_25_no_tag_allows(self, tmp_path):
+        _init_repo_with_staged(tmp_path, 25)
+        code = _run('git commit -m "tiny fix"', tmp_path)
+        assert code == 0, (
+            "25-line staged diff with no tag must ALLOW (exit 0) — "
+            f"under the 800-line threshold. Got exit {code}."
+        )
+
+    def test_900_mvp_substring_no_brackets_blocks(self, tmp_path):
+        """Adversarial: 'fixed a bug with the MVP flow' contains 'MVP' as a
+        substring but not as the literal bracketed token '[MVP]'. The gate's
+        TAG_RE regex requires the literal bracketed form, so this must BLOCK.
+        A fail-open / substring-matching implementation would ALLOW.
+        """
+        _init_repo_with_staged(tmp_path, 900)
+        code = _run('git commit -m "fixed a bug with the MVP flow"', tmp_path)
+        assert code == 2, (
+            "Adversarial substring 'MVP flow' (no brackets) must BLOCK (exit 2). "
+            f"Got exit {code} — substring matching is leaking, gate is broken."
+        )


### PR DESCRIPTION
## Summary

Promotes the validated Rule 11 (Commit-Size Acknowledgment Gate) implementation into `hardgate` as the canonical reusable template. After this PR lands, `templates/commit-size-gate/` is the blessed reference for the rule — byte-identical to the production deployment in `civiccore`, `scottconverse/patentforgelocal` (`007e924`), and `scottconverse/productteam` (`76333aa`).

## What's included

- **`templates/commit-size-gate/`** — 5-file template:
  - `commit-size-gate.py` (183 lines, PreToolUse blocker)
  - `commit-size-gate.sh` (bash wrapper)
  - `commit-size-session-start.py` + `.sh` (SessionStart reminder)
  - `README.md` — install steps, tunables, bypass surfaces, verification recipe, validation provenance
- **`CHANGELOG.md`** — new `[Unreleased]` > `Added` entry documenting the template set
- **`README.md`** — new "Canonical templates" section after the 7-artifacts table, announcing the template shelf and linking into the template README
- **`tests/commit_size_gate_template_test.py`** — pytest smoke test executing the real template file (not a fixture copy) against temp git repos. Covers all 4 behavioral cases plus a template-file-exists guard. 5/5 passing locally.

## Validation

Template behavior was verified across three active projects before promotion:

| Project | Reference | Stack |
|---|---|---|
| `civiccore` | validation project (`.claude/` gitignored, local-only) | Python |
| `scottconverse/patentforgelocal` | commit `007e924` (repo-shared) | NestJS + Vite |
| `scottconverse/productteam` | commit `76333aa` (repo-shared) | Python package |

All four behavioral cases passed 12/12 across those three projects:
- 900-line staged diff, no tag → BLOCK (exit 2)
- 900-line staged diff, `[MVP]` tag → ALLOW (exit 0)
- 25-line staged diff, no tag → ALLOW (exit 0)
- 900-line staged diff, substring "MVP flow" (no brackets) → BLOCK (exit 2)

`tests/commit_size_gate_template_test.py` replays those exact cases against the template file in this PR. Local run: `5 passed in 1.50s`.

## Out of scope

- No hook semantics changes: `THRESHOLD`, regexes, bypass surfaces (`--amend`, `-F`, editor commits), and override-marker logic are unchanged from the validated rollout.
- No installer flow changes: `SKILL.md`, `INSTALL.md`, `USER-MANUAL.md`, `hard-gate.md`, `disable-gate.md`, and `installer/` are untouched.
- No new gates added.
- No `docs/index.html` or release-asset updates.
- No touches to `civiccore` or `civicrecords-ai` projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)