### PR TITLE
chore(ci): migrate Linux jobs to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   # -----------------------------------------------------------------------
   test-install-sh:
     name: install.sh (Linux)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,7 +34,7 @@ jobs:
   # -----------------------------------------------------------------------
   installer-drift-check:
     name: installer drift check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -80,7 +80,7 @@ jobs:
   # -----------------------------------------------------------------------
   pytest:
     name: "pytest / Python ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Migrates Linux jobs to runs-on: [self-hosted, linux, x64], targeting the new self-hosted runner registered to this repo (`nvideablackwell-hardgate-2404`). Windows-latest / macos-latest jobs preserved (no self-hosted runner for those OSes).

Runner host: WSL Ubuntu 24.04 LTS on new-box (NvideaBlackwell, RTX 5070).

Pattern follows [CivicSuite/civicsuite#133](https://github.com/CivicSuite/civicsuite/pull/133) (merged a9bb54a, full CI green on self-hosted).